### PR TITLE
allow methods with 0 arguments

### DIFF
--- a/interface.js
+++ b/interface.js
@@ -11,11 +11,11 @@ const getArgs = (func) => {
 
     switch (typeof func) {
         case 'function': {
-            args = func.toString().match(/\(\s*([^)]+?)\s*\)/);
+            args = func.toString().match(/\(\s*([^)]*?)\s*\)/);
             break;
         }
         case 'string': {
-            args = func.match(/\(\s*([^)]+?)\s*\)/);
+            args = func.match(/\(\s*([^)]*?)\s*\)/);
             break;
         }
         default: {


### PR DESCRIPTION
Changing the regex + to an * allows functions with no arguments to still be matched correctly