### PR TITLE
Feature: shorthand syntax for es6 object methods

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,16 @@
+module.exports = {
+	env: {
+		browser: true,
+		node: true,
+		mocha: true,
+		es2021: true,
+	},
+	extends: ['eslint:recommended'],
+	globals: {
+		define: 'readonly',
+	},
+	parserOptions: {},
+	rules: {
+		indent: ['error', 'tab', { SwitchCase: 1 }],
+	},
+};

--- a/README.md
+++ b/README.md
@@ -1,34 +1,69 @@
-<h1>es6-interface</h1>
-es6-interfac is a Nodejs module  that let you build interfaces for es6 classes
+# `es6-interface`
 
-<h2>Introduction</h2>
-in today javascript there is no way to declare an interface like other language's as php or java.
-with es6-interface easily build interfaces , use multi interfaces on the same class and secure your class.
+This module creates extendable ES6 Classes from method signatures that can be defined in objects or string lists, resulting in something similar to class Interfaces.
+
+It will throw an exception, at runtime, if the implementation class do not implement all methods with the same arguments declared in the interfaces.
+
+**Notice**: because the implementation relies on code reflection methods, it might not work on minified/uglified version of your code, like those generated in the production build phase by some frontend frameworks.
+
+## Quick Start
+
+```js
+const Interface = require("es6-interface");
+
+const MyInterface1 = {
+  requiredMethod1({ arg1, arg2 }) {}
+}
+
+const MyInterface2 = new Set[
+  "requiredMethod2({ arg1, arg2 })",
+];
+
+class MyClass extends Interface(MyInterface1, MyInterface2) {
+  requiredMethod1({ arg1, arg2 }) {
+     console.log("Hello from requiredMethod1");
+  }
+
+  requiredMethod2({ arg1 }) {
+     console.log("Hello from requiredMethod2");
+  }
+}
+```
+
+This code will throw an exception:
+> ```sh
+> MyClass must implement requiredMethod2({arg1,arg2}) methods
+> ```
 
 
+## Limitations
 
-<h2>Limitations</h2>
-works on NodeJS version 6+,
-works only on modern web browsers,
-tested only on NodeJS
-<h2>Installing</h2>
+- works on NodeJS version 6+,
+- works only on modern web browsers,
+- tested only on NodeJS
+ 
+## Installing
 
 ```
 npm install es6-interface --save
 ```
-<h2>Declaring an interface</h2>
-there are 3 ways to declare an interface
-as a set , array or an object. the most common way is using and object.
-check the tests file if you want to declare using sets
 
-lets jump to some examples
-<h2>Examples</h2>
+## Declaring an interface
 
-first we start with a simple 1 interface implementation
-<h2>One interface implementation</h2> 
+There are 3 ways to declare an interface:
+- Set: ```const IFoo = new Set["method1(arg1)","method2(arg1)"]```
+- Array: ```const IFoo = ["method1(arg1)","method2(arg1)"]```
+- Object: ```const IFoo { method1() {}, method2() {} }```
+
+Also, an Interface can extend one parent class.
+
+## Examples
+
+First we start with a simple 1 interface implementation
+
+### One interface implementation
 
 ```javascript
-
 const Interface = require('es6-interface')
 const testInterface1 = {
     required1: function(arg1) {
@@ -38,88 +73,66 @@ class testClass extends Interface(testInterface1) {
   constructor() {
     super()
   }
-
 }
 
 new testClass() // now we will get an error that we need to implement required1(arg1) method
-
 ```
 
 
-<h2>Multi interface implementation</h2> 
+### Multi interface implementation
 
 ```javascript
-
 const Interface = require('es6-interface');
 const testInterface1 = {
-    required1: function(arg1) {
-    }
+    required1(arg1) {}
 };
 const testInterface2 = {    
-    required2: function (arg1, arg2) {
-    },
-    required3: function({arg1, arg2, arg3}) {
-    }
+    required2(arg1, arg2) {},
+    required3({arg1, arg2, arg3}) {}
 };
 class testClass extends Interface(testInterface1,testInterface2) {
   constructor() {
     super()
   }
-
 }
 
 new testClass() // now we will get an error that we need to implement required1(arg1) required2(arg1,arg2) required3({arg1,arg2,arg3}) methods
 ```
 
-<h2>Multi interface with class inheritance </h2> 
+### Multi interface with class inheritance
 
 ```javascript
-
 const Interface = require('es6-interface');
 const testInterface1 = {
-    required1: function(arg1) {
-    }
+    required1(arg1) {}
 };
 const testInterface2 = {    
-    required2: function (arg1, arg2) {
-    },
-    required3: function({arg1, arg2, arg3}) {
-    }
+    required2(arg1, arg2) {},
+    required3({arg1, arg2, arg3}) {}
 };
 const testInterface4 = {
-    required4: function ({arg1, arg2, arg3}, arg4) {
-    }
+    required4({arg1, arg2, arg3}, arg4) {}
 };
 class parentClass {
-    constructor() {
-
-    }
-    
-    required4({arg1, arg2, arg3}, arg4) {
-
-    }
+    constructor() {}  
+    required4({arg1, arg2, arg3}, arg4) {}
 }
 class testClass extends Interface(testInterface1,testInterface2,testInterface4,parentClass) {
   constructor() {
     super()
   }
-
 }
 
 new testClass() //  we will still get an error for no implement required1(arg1) required2(arg1,arg2) required3({arg1,arg2,arg3}) methods as we get required4 from our parent class
 ```
 
-<h2>Next development tasks</h2> 
-<ul>
-    <li>improve performance</li>
-    <li>better error messages </li>
-</ul>
+### Next development tasks
 
-<h2>Tests</h2>
+- improve performance
+- better error messages
+
+### Tests
 
 ```
 npm test
 ```
-
-
-

--- a/interface.js
+++ b/interface.js
@@ -60,9 +60,19 @@ function getMethodsFromObject(obj) {
 					funcStr.substr(0, funcStr.lastIndexOf('{')).replace('function', '')
 				);
 			} else if (funcStr.includes('(')) {
-				return (
-					funcName + funcStr.substr(funcStr.indexOf('('), funcStr.indexOf('='))
-				);
+				if (funcStr.includes('=')) {
+					// fn: () => {}
+					return (
+						funcName +
+						funcStr.substr(funcStr.indexOf('('), funcStr.indexOf('='))
+					);
+				} else {
+					// fn() {}
+					return (
+						funcName +
+						funcStr.substr(funcStr.indexOf('('), funcStr.lastIndexOf('{'))
+					);
+				}
 			} else {
 				return funcName + '(' + funcStr.substr(0, funcStr.indexOf('=')) + ')';
 			}

--- a/interface.js
+++ b/interface.js
@@ -1,3 +1,7 @@
+String.prototype.removeAllSpaces = function () {
+	return this.replace(/\s+/g, '');
+};
+
 const getClassMethodNames = (obj) => {
 	let methods = new Set();
 	while (obj = Reflect.getPrototypeOf(obj)) {
@@ -11,11 +15,14 @@ const getArgs = (func) => {
 
 	switch (typeof func) {
 		case 'function': {
-			args = func.toString().match(/\(\s*([^)]*?)\s*\)/);
+			args = func
+				.toString()
+				.removeAllSpaces()
+				.match(/\(\s*([^)]*?)\s*\)/);
 			break;
 		}
 		case 'string': {
-			args = func.match(/\(\s*([^)]*?)\s*\)/);
+			args = func.removeAllSpaces().match(/\(\s*([^)]*?)\s*\)/);
 			break;
 		}
 		default: {
@@ -40,7 +47,7 @@ class DummyClassForExtendsIfNoClassWasSendToAvoidError {
 
 function getMethodsFromObject(obj) {
 	return Object.keys(obj).filter(funcName => typeof obj[funcName] === "function").map(funcName => {
-		const funcStr = obj[funcName].toString();
+		const funcStr = obj[funcName].toString().removeAllSpaces();
 		if (funcStr.includes("function")) {
 			return funcName + funcStr.substr(0, funcStr.lastIndexOf("{")).replace("function", "");
 		} else if (funcStr.includes("(")) {

--- a/interface.js
+++ b/interface.js
@@ -4,7 +4,7 @@ String.prototype.removeAllSpaces = function () {
 
 const getClassMethodNames = (obj) => {
 	let methods = new Set();
-	while (obj = Reflect.getPrototypeOf(obj)) {
+	while ((obj = Reflect.getPrototypeOf(obj))) {
 		let keys = Reflect.ownKeys(obj);
 		keys.forEach((k) => methods.add(k));
 	}
@@ -31,35 +31,45 @@ const getArgs = (func) => {
 	}
 
 	if (args === null || !args[1]) {
-		return "";
+		return '';
 	}
 	args = args[1];
-	return args.split(/\s*,\s*/).map((arg) => {
-		return arg.replace(/\/\*.*\*\//, '').replace(/=.*/, "").trim();
-	}).filter(arg => {
-		return arg;
-	});
+	return args
+		.split(/\s*,\s*/)
+		.map((arg) => {
+			return arg
+				.replace(/\/\*.*\*\//, '')
+				.replace(/=.*/, '')
+				.trim();
+		})
+		.filter((arg) => {
+			return arg;
+		});
 };
 
-
-class DummyClassForExtendsIfNoClassWasSendToAvoidError {
-}
+class DummyClassForExtendsIfNoClassWasSendToAvoidError {}
 
 function getMethodsFromObject(obj) {
-	return Object.keys(obj).filter(funcName => typeof obj[funcName] === "function").map(funcName => {
-		const funcStr = obj[funcName].toString().removeAllSpaces();
-		if (funcStr.includes("function")) {
-			return funcName + funcStr.substr(0, funcStr.lastIndexOf("{")).replace("function", "");
-		} else if (funcStr.includes("(")) {
-			return funcName + funcStr.substr(funcStr.indexOf("("), funcStr.indexOf("="));
-		} else {
-			return funcName + "(" + funcStr.substr(0, funcStr.indexOf("=")) + ")";
-		}
-	});
+	return Object.keys(obj)
+		.filter((funcName) => typeof obj[funcName] === 'function')
+		.map((funcName) => {
+			const funcStr = obj[funcName].toString().removeAllSpaces();
+			if (funcStr.includes('function')) {
+				return (
+					funcName +
+					funcStr.substr(0, funcStr.lastIndexOf('{')).replace('function', '')
+				);
+			} else if (funcStr.includes('(')) {
+				return (
+					funcName + funcStr.substr(funcStr.indexOf('('), funcStr.indexOf('='))
+				);
+			} else {
+				return funcName + '(' + funcStr.substr(0, funcStr.indexOf('=')) + ')';
+			}
+		});
 }
 
-const container = function (options) {
-
+const container = function () {
 	if (container.arguments.length === 0) {
 		throw new Error('you need to supply at least one interface');
 	}
@@ -69,15 +79,23 @@ const container = function (options) {
 	let Class = null;
 
 	for (let i in container.arguments) {
-
-		if (container.arguments[i] instanceof Set || Array.isArray(container.arguments[i])) {
+		if (
+			container.arguments[i] instanceof Set ||
+			Array.isArray(container.arguments[i])
+		) {
 			arr = [...arr, ...container.arguments[i]];
-		} else if (typeof container.arguments[i] === "object" && container.arguments[i] !== null) {
+		} else if (
+			typeof container.arguments[i] === 'object' &&
+			container.arguments[i] !== null
+		) {
 			arr = [...arr, ...getMethodsFromObject(container.arguments[i])];
-		} else if (parseInt(i) + 1 === argLength && typeof container.arguments[i] === "function") {
+		} else if (
+			parseInt(i) + 1 === argLength &&
+			typeof container.arguments[i] === 'function'
+		) {
 			Class = container.arguments[i];
 		} else {
-			throw new Error("interfaces can be an Array Set or Object");
+			throw new Error('interfaces can be an Array Set or Object');
 		}
 	}
 
@@ -87,23 +105,28 @@ const container = function (options) {
 	}
 
 	class Interface extends Class {
-
 		constructor(options) {
 			super(options);
 
 			const ClassMethods = getClassMethodNames(this);
-			let errors = "";
-			requiredMethods.forEach(key => {
-				let methodNameIndex = key.indexOf("(");
-				let methodName = methodNameIndex > -1 ? key.substr(0, methodNameIndex) : key;
+			let errors = '';
+			requiredMethods.forEach((key) => {
+				let methodNameIndex = key.indexOf('(');
+				let methodName =
+					methodNameIndex > -1 ? key.substr(0, methodNameIndex) : key;
 				methodName = methodName.trim();
-				if (ClassMethods.has(methodName) === false || getArgs(this[methodName]).toString() !== getArgs(key).toString()) {
-					errors += `${methodName}(${getArgs(key)})`.replace(/\s+/g, '') + " ";
+				if (
+					ClassMethods.has(methodName) === false ||
+					getArgs(this[methodName]).toString() !== getArgs(key).toString()
+				) {
+					errors += `${methodName}(${getArgs(key)})`.replace(/\s+/g, '') + ' ';
 				}
 			});
 
 			if (errors) {
-				throw  new Error(this.constructor.name + ' must implement ' + errors + 'methods');
+				throw new Error(
+					this.constructor.name + ' must implement ' + errors + 'methods'
+				);
 			}
 		}
 	}
@@ -124,5 +147,3 @@ if (typeof define === 'function' && define.amd) {
 }
 
 window.es6Interface = container;
-
-

--- a/package.json
+++ b/package.json
@@ -1,30 +1,32 @@
 {
-  "name": "es6-interface",
-  "version": "3.1.4",
-  "description": "this module helps you build interfaces for es6 class",
-  "main": "interface.js",
-  "dependencies": {},
-  "devDependencies": {
-    "chai": "^4.1.2",
-    "mocha": "^5.2.0"
-  },
-  "scripts": {
-    "test": "mocha --timeout 10000"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/amit221/es6-interface.git"
-  },
-  "keywords": [
-    "es6",
-    "interface",
-    "class",
-    "javascript"
-  ],
-  "author": "Amit Wagner",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/amit221/interface/issues"
-  },
-  "homepage": "https://github.com/amit221/interface#readme"
+	"name": "es6-interface",
+	"version": "3.1.4",
+	"description": "this module helps you build interfaces for es6 class",
+	"main": "interface.js",
+	"devDependencies": {
+		"chai": "^4.1.2",
+		"eslint": "^7.26.0",
+		"mocha": "^5.2.0",
+		"prettier": "^2.3.0"
+	},
+	"scripts": {
+		"test": "mocha --timeout 10000",
+		"lint": "eslint ."
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/amit221/es6-interface.git"
+	},
+	"keywords": [
+		"es6",
+		"interface",
+		"class",
+		"javascript"
+	],
+	"author": "Amit Wagner",
+	"license": "MIT",
+	"bugs": {
+		"url": "https://github.com/amit221/interface/issues"
+	},
+	"homepage": "https://github.com/amit221/interface#readme"
 }

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	singleQuote: true,
+	useTabs: true,
+};

--- a/test/interface.js
+++ b/test/interface.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 'use strict';
 
 const chai = require('chai');
@@ -6,40 +7,32 @@ const Interface = require('../interface');
 
 const testInterface1 = new Set(['required1(arg1)']);
 const testInterface1Object = {
-	required1: arg1 => {
-	}
+	required1: (arg1) => {},
 };
-const testInterface2 = new Set(['required2(arg1,arg2)', 'required3({arg1 , arg2 , arg3})']);
+const testInterface2 = new Set([
+	'required2(arg1,arg2)',
+	'required3({arg1 , arg2 , arg3})',
+]);
 const testInterface2Object = {
-	required2: function (arg1, arg2) {
-	},
-	required3: ({arg1, arg2, arg3}) => {
-	}
+	required2: function (arg1, arg2) {},
+	required3: ({ arg1, arg2, arg3 }) => {},
 };
 const testInterface3 = new Set(['missingArgumentMethod(arg1)']);
 const testInterface3Object = {
-	missingArgumentMethod: function (arg1) {
-	}
+	missingArgumentMethod: function (arg1) {},
 };
 const testInterface4 = new Set(['required4({arg1, arg2, arg3}, arg4)']);
 const testInterface4Object = {
-	required4: function ({arg1, arg2, arg3}, arg4) {
-	}
+	required4: function ({ arg1, arg2, arg3 }, arg4) {},
 };
 
 class parentClass {
-	constructor() {
+	constructor() {}
 
-	}
-
-	required4({arg1, arg2, arg3}, arg4) {
-
-	}
+	required4({ arg1, arg2, arg3 }, arg4) {}
 }
 
-
 describe('Interface', () => {
-
 	it('should throw error if no interfaces supplied ', () => {
 		try {
 			class testClass extends Interface() {
@@ -47,9 +40,8 @@ describe('Interface', () => {
 					super();
 				}
 			}
-
 		} catch (err) {
-			expect(err.message).to.equal("you need to supply at least one interface");
+			expect(err.message).to.equal('you need to supply at least one interface');
 		}
 	});
 	it('should throw error if interface is not instance of Set Array ot Object', () => {
@@ -62,7 +54,7 @@ describe('Interface', () => {
 
 			new testClass();
 		} catch (err) {
-			expect(err.message).to.equal("interfaces can be an Array Set or Object");
+			expect(err.message).to.equal('interfaces can be an Array Set or Object');
 		}
 	});
 	it('should throw error class did not implemented testInterface1 interface ', () => {
@@ -75,7 +67,9 @@ describe('Interface', () => {
 
 			new testClass();
 		} catch (err) {
-			expect(err.message).to.equal("testClass must implement required1(arg1) methods");
+			expect(err.message).to.equal(
+				'testClass must implement required1(arg1) methods'
+			);
 		}
 	});
 	it('should throw error class did not implemented testInterface1Object interface ', () => {
@@ -88,10 +82,11 @@ describe('Interface', () => {
 
 			new testClass();
 		} catch (err) {
-			expect(err.message).to.equal("testClass must implement required1(arg1) methods");
+			expect(err.message).to.equal(
+				'testClass must implement required1(arg1) methods'
+			);
 		}
 	});
-
 
 	it('should throw error class did not implemented testInterface3 interface ', () => {
 		try {
@@ -100,13 +95,14 @@ describe('Interface', () => {
 					super();
 				}
 
-				required6() {
-				}
+				required6() {}
 			}
 
 			new testClass();
 		} catch (err) {
-			expect(err.message).to.equal("testClass must implement missingArgumentMethod(arg1) methods");
+			expect(err.message).to.equal(
+				'testClass must implement missingArgumentMethod(arg1) methods'
+			);
 		}
 	});
 	it('should throw error class did not implemented testInterface3Object interface ', () => {
@@ -116,16 +112,16 @@ describe('Interface', () => {
 					super();
 				}
 
-				required6() {
-				}
+				required6() {}
 			}
 
 			new testClass();
 		} catch (err) {
-			expect(err.message).to.equal("testClass must implement missingArgumentMethod(arg1) methods");
+			expect(err.message).to.equal(
+				'testClass must implement missingArgumentMethod(arg1) methods'
+			);
 		}
 	});
-
 
 	it('should throw error class did not implemented testInterface1 and testInterface2 interface ', () => {
 		try {
@@ -137,12 +133,17 @@ describe('Interface', () => {
 
 			new testClass();
 		} catch (err) {
-			expect(err.message).to.equal("testClass must implement required1(arg1) required2(arg1,arg2) required3({arg1,arg2,arg3}) methods");
+			expect(err.message).to.equal(
+				'testClass must implement required1(arg1) required2(arg1,arg2) required3({arg1,arg2,arg3}) methods'
+			);
 		}
 	});
 	it('should throw error class did not implemented testInterface1Object and testInterface2Object interface ', () => {
 		try {
-			class testClass extends Interface(testInterface1Object, testInterface2Object) {
+			class testClass extends Interface(
+				testInterface1Object,
+				testInterface2Object
+			) {
 				constructor() {
 					super();
 				}
@@ -150,39 +151,50 @@ describe('Interface', () => {
 
 			new testClass();
 		} catch (err) {
-			expect(err.message).to.equal("testClass must implement required1(arg1) required2(arg1,arg2) required3({arg1,arg2,arg3}) methods");
+			expect(err.message).to.equal(
+				'testClass must implement required1(arg1) required2(arg1,arg2) required3({arg1,arg2,arg3}) methods'
+			);
 		}
 	});
-
 
 	it('should throw error class did not implemented testInterface1 and testInterface2 interface ', () => {
 		try {
-			class testClass extends Interface(testInterface1, testInterface2, testInterface4, parentClass) {
+			class testClass extends Interface(
+				testInterface1,
+				testInterface2,
+				testInterface4,
+				parentClass
+			) {
 				constructor() {
 					super();
 				}
-
 			}
 
 			new testClass();
 		} catch (err) {
-			expect(err.message).to.equal("testClass must implement required1(arg1) required2(arg1,arg2) required3({arg1,arg2,arg3}) methods");
+			expect(err.message).to.equal(
+				'testClass must implement required1(arg1) required2(arg1,arg2) required3({arg1,arg2,arg3}) methods'
+			);
 		}
 	});
 	it('should throw error class did not implemented testInterface1Object and testInterface2Object interface ', () => {
 		try {
-			class testClass extends Interface(testInterface1Object, testInterface2Object, testInterface4Object, parentClass) {
+			class testClass extends Interface(
+				testInterface1Object,
+				testInterface2Object,
+				testInterface4Object,
+				parentClass
+			) {
 				constructor() {
 					super();
 				}
-
 			}
 
 			new testClass();
 		} catch (err) {
-			expect(err.message).to.equal("testClass must implement required1(arg1) required2(arg1,arg2) required3({arg1,arg2,arg3}) methods");
+			expect(err.message).to.equal(
+				'testClass must implement required1(arg1) required2(arg1,arg2) required3({arg1,arg2,arg3}) methods'
+			);
 		}
 	});
-
-
 });

--- a/test/interface.js
+++ b/test/interface.js
@@ -26,6 +26,16 @@ const testInterface4Object = {
 	required4: function ({ arg1, arg2, arg3 }, arg4) {},
 };
 
+const testInterface5Object = {
+	required5({ arg1, arg2 }) {},
+};
+
+class testInterface6Class {
+	required6({ arg1, arg2 }) {}
+}
+
+const testInterface7Array = ['required7({ arg1, arg2 })'];
+
 class parentClass {
 	constructor() {}
 
@@ -157,7 +167,7 @@ describe('Interface', () => {
 		}
 	});
 
-	it('should throw error class did not implemented testInterface1 and testInterface2 interface ', () => {
+	it('should throw error class did not implemented testInterface1, testInterface2, testInterface4 interface ', () => {
 		try {
 			class testClass extends Interface(
 				testInterface1,
@@ -194,6 +204,51 @@ describe('Interface', () => {
 		} catch (err) {
 			expect(err.message).to.equal(
 				'testClass must implement required1(arg1) required2(arg1,arg2) required3({arg1,arg2,arg3}) methods'
+			);
+		}
+	});
+	it('should throw error class did not implement testInterface5Object methods', () => {
+		try {
+			class testClass extends Interface(testInterface5Object) {
+				constructor() {
+					super();
+				}
+			}
+
+			new testClass();
+		} catch (err) {
+			expect(err.message).to.equal(
+				'testClass must implement required5({arg1,arg2}) methods'
+			);
+		}
+	});
+	it('should throw error class did not implement testInterface6Class methods', () => {
+		try {
+			class testClass extends Interface(testInterface6Class) {
+				constructor() {
+					super();
+				}
+			}
+
+			new testClass();
+		} catch (err) {
+			expect(err.message).to.equal(
+				'testClass must implement required6({arg1,arg2}) methods'
+			);
+		}
+	});
+	it('should throw error class did not implement testInterface7Array methods', () => {
+		try {
+			class testClass extends Interface(testInterface7Array) {
+				constructor() {
+					super();
+				}
+			}
+
+			new testClass();
+		} catch (err) {
+			expect(err.message).to.equal(
+				'testClass must implement required7({arg1,arg2}) methods'
 			);
 		}
 	});


### PR DESCRIPTION
Implements https://github.com/amit221/es6-interface/issues/4

This code contains https://github.com/amit221/es6-interface/pull/5 but I've opened two PRs to avoid mixed concerns.

Additional changes in this PR:
- enable eslint+prettier with tab indent in the project
- update the README with information on this syntax

@amit221 here I took the freedom to rewrite a bunch of things in the README. Again, feel free to submit your feedback e reject the PR if changes are needed.