### PR TITLE
fix: syntax error on browsers - illegal return

### DIFF
--- a/interface.js
+++ b/interface.js
@@ -146,14 +146,10 @@ const container = function () {
 
 if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {
 	module.exports = container;
-	return;
-}
-
-if (typeof define === 'function' && define.amd) {
+} else if (typeof define === 'function' && define.amd) {
 	define([], function () {
 		return container;
 	});
-	return;
+} else {
+	window.es6Interface = container;
 }
-
-window.es6Interface = container;


### PR DESCRIPTION
When using es6-interface on a frontend application, VueJS on Chrome, we get a syntax error - Illegal return. See attached image. The reason for that exception is that the browser won't allow a return statement from the main body of the module. This patch replaces the return with a chain of if-else statements.
![Screenshot_2021-05-26_00-26-24](https://user-images.githubusercontent.com/1676528/119600014-805cd180-bdbc-11eb-91e9-b4070e267549.png)
